### PR TITLE
Greedy Algorithm Speedups

### DIFF
--- a/src/python/greedy.py
+++ b/src/python/greedy.py
@@ -5,7 +5,7 @@ import time
 
 # A greedy algorithm to factorize, adapted from Maple code of Andrew Sutherland. (Thanks to Adam Wagner for help with the code conversion to Python.)
 
-def solve(N,T):
+def solve(N, T, skip_tests=True):
     P = list(sympy.primerange(1, T))
     pi = {p: i+1 for i, p in enumerate(P)}  # Use dictionary for mapping primes to indices
     
@@ -40,6 +40,7 @@ def solve(N,T):
 
         # Search for the smallest m such that m * p >= T
         m = max(math.ceil(T / P[i-1]), minm)
+        divisions = 1
         while m < T:
             F = factorint(m)
 
@@ -50,12 +51,13 @@ def solve(N,T):
             X[i] = X.get(i, 0) + 1  # Increment the exponent of the current prime by 1 (essentially changing to m * p from m)
             
             # Check to make sure that m * p can divide our number evenly. If this condition is met, break the loop
-            valid_m = True
+            divisions = 10**10 # set arbitrarily high to start
             for j in X:
-                if E.get(j, 0) < X[j]:
-                    valid_m = False
+                factor_divisions = E.get(j, 0) // X[j]
+                divisions = min(divisions, factor_divisions)
+                if factor_divisions == 0:
                     break
-            if valid_m:
+            if divisions >= 1: # can divide at least once
                 break
             
             m += 1
@@ -66,11 +68,16 @@ def solve(N,T):
         if m == T:
             break
         
+        # print(f"Found factor {P[i-1] * m}")
+        if P[i-1] * m not in divisors:
+            divisors[P[i-1] * m] = 0
+        divisors[P[i-1] * m] += divisions
+
         # Factor m * p out of our current number
         for j in X:
-            E[j] = E.get(j, 0) - X[j]
+            E[j] = E.get(j, 0) - X[j] * divisions
 
-        L.append(m * P[i-1])
+        L.extend([m * P[i-1]] * divisions)
 
     t_end = time.time()
 

--- a/src/python/greedy.py
+++ b/src/python/greedy.py
@@ -7,9 +7,9 @@ import time
 
 def solve(N, T, skip_tests=True):
     P = list(sympy.primerange(1, T))
-    pi = {p: i+1 for i, p in enumerate(P)}  # Use dictionary for mapping primes to indices
+    pi = {p: i for i, p in enumerate(P)}  # Use dictionary for mapping primes to indices
     
-    E = {}  # Use dictionary to store exponents of primes in N!
+    E = []  # Use list to store exponents of primes in N!
 
     # For each prime, count its exponent in the factorization of N! by examining the prime exponents one at a time. For example, for 20! and p = 2,
     # we would note that 20 // 2 = 10, 20 // 4 = 5, 20 // 8 = 2, and 20 // 16 = 1, so there must be 10+5+2+1 = 18 factors
@@ -17,13 +17,13 @@ def solve(N, T, skip_tests=True):
         exponent = 0
         for i in range(1, int(math.log(N, p)) + 1):
             exponent += N // (p**i)
-        E[pi[p]] = exponent
+        E.append(exponent)
 
     L = []  # Use list to store all factors
     for p in sympy.primerange(T, N + 1):  # All primes of size >= T can be directly added to the factorization
         L.extend([p] * (N // p))
 
-    i = len(P)  # Current prime to examine (we start with the largest prime in the range)
+    i = len(P)-1  # Current prime to examine (we start with the largest prime in the range)
     minm = 0
     t_start = time.time()
 
@@ -33,13 +33,13 @@ def solve(N, T, skip_tests=True):
     # 3. Factor out m * p and then repeat this algorithm on the resulting number
     while True:
         # If the current prime has an exponent of zero in the factorization, move on to the next-largest prime
-        while i > 0 and E.get(i, 0) == 0:
+        while i >= 0 and E[i] == 0:
             i -= 1
-        if i == 0:
+        if i < 0:
             break
 
         # Search for the smallest m such that m * p >= T
-        m = max(math.ceil(T / P[i-1]), minm)
+        m = max(math.ceil(T / P[i]), minm)
         divisions = 1
         while m < T:
             F = factorint(m)
@@ -53,7 +53,7 @@ def solve(N, T, skip_tests=True):
             # Check to make sure that m * p can divide our number evenly. If this condition is met, break the loop
             divisions = 10**10 # set arbitrarily high to start
             for j in X:
-                factor_divisions = E.get(j, 0) // X[j]
+                factor_divisions = E[j] // X[j]
                 divisions = min(divisions, factor_divisions)
                 if factor_divisions == 0:
                     break
@@ -61,7 +61,7 @@ def solve(N, T, skip_tests=True):
                 break
             
             m += 1
-            if E.get(i,0) >= X.get(i,0):  # On future iterations of the loop, skip every m up to this point 
+            if E[i] >= X.get(i,0):  # On future iterations of the loop, skip every m up to this point 
                 minm = m
 
         # If we have reached our upper limit, then we are done
@@ -70,9 +70,9 @@ def solve(N, T, skip_tests=True):
 
         # Factor m * p out of our current number
         for j in X:
-            E[j] = E.get(j, 0) - X[j] * divisions
+            E[j] = E[j] - X[j] * divisions
 
-        L.extend([m * P[i-1]] * divisions)
+        L.extend([m * P[i]] * divisions)
 
     t_end = time.time()
 

--- a/src/python/greedy.py
+++ b/src/python/greedy.py
@@ -74,22 +74,24 @@ def solve(N,T):
 
     t_end = time.time()
 
-    # Confirm that all factors in L are at least T
-    assert all(n >= T for n in L)
-    
-    # Confirm that the product of L evenly divides N!
-    product_L = 1
-    for n in L:
-        product_L *= n
+    # Run assurance tests (can be extremely time intensive)
+    if not skip_tests:
+        # Confirm that all factors in L are at least T
+        assert all(n >= T for n in L)
         
-    factorial_N = math.factorial(N)
+        # Confirm that the product of L evenly divides N!
+        product_L = 1
+        for n in L:  # Note: this computation is by far the most time intensive part
+            product_L *= n
+            
+        factorial_N = math.factorial(N)
 
-    if factorial_N % product_L == 0:
-        is_divisible = True
-    else:
-        is_divisible = False
-        
-    assert is_divisible
+        if factorial_N % product_L == 0:
+            is_divisible = True
+        else:
+            is_divisible = False
+            
+        assert is_divisible
 
     # Report results
     print(f"Tested N={N} against T={T}")

--- a/src/python/greedy.py
+++ b/src/python/greedy.py
@@ -67,11 +67,6 @@ def solve(N, T, skip_tests=True):
         # If we have reached our upper limit, then we are done
         if m == T:
             break
-        
-        # print(f"Found factor {P[i-1] * m}")
-        if P[i-1] * m not in divisors:
-            divisors[P[i-1] * m] = 0
-        divisors[P[i-1] * m] += divisions
 
         # Factor m * p out of our current number
         for j in X:


### PR DESCRIPTION
Implemented some small speedups for the greedy algorithm. In particular:
- Added the ability to toggle the assert statements at the end. It turned out that multiplying all the factors together was taking around 10x - 20x times as long as the actual algorithm runtime
- When looking at the factors, I noticed that the same numbers were being factored out multiple times (often hundreds of times). I changed the loop to automatically factor out a number as many times as it can in one go rather than running multiple loops. This yielded a 2x - 3x speedup.
- Changed from having our primes as a dictionary to having them as a list. This did not yield a major speedup, but I hope it will come in handy with some of the further optimizations I've been thinking about.