### PR TITLE
fix(smoothfac): Use correct multiplicity when adding greedy factors

### DIFF
--- a/src/linprog/smoothfac.py
+++ b/src/linprog/smoothfac.py
@@ -199,7 +199,7 @@ def main(N: int, T: int, filename: Optional[str], lp_filename: Optional[str]):
             break
         # record greedy factor
         nf_grdy += m
-        sc[j] = sc.setdefault(j, 0) + 1
+        sc[j] = sc.setdefault(j, 0) + m
         # 'deflate' LP factors
         while j > 1:
             k = f[j]


### PR DESCRIPTION
This commit fixes a bug in the `smoothfac` program. It fails to correctly record the multiplicity of factors in the final step.

This should fix #20.