### PR TITLE
add version numbers to fastegs dependencies on primesieve/primecount

### DIFF
--- a/src/fastegs/README.md
+++ b/src/fastegs/README.md
@@ -6,7 +6,7 @@ This implemention depends on Kim Walisch's [primesieve](https://github.com/kimwa
 
 These two libraries are used to efficiently handle factors divisible by primes in the range $$[\sqrt{t},N]$$. In this range the greedy algorithm can always use the optimal cofactor $$m = \lceil\frac{t}{p}\rceil$$ to construct $$n = v_p(N!)$$ factors $$mp \ge t$$ that are as small as possible (given that they are divisible by $p$).  To improve efficiency, the algorithm subdivides the interval $$[\sqrt{t},N]$$ into regions within which the values of $m$ and $n$ are constant and simply counts the primes in each region (for small regions it uses `primesieve` to enuemrate primes, for large regions $$[a,b]$$ it uses `primecount` to compute $$\pi(b)-\pi(a-1))$$.  See the paper for more details.
 
-To verify the Erdos-Guy-Selfridge conjecture for $$N$$ in $$[67425,10^{11}]$$ (which is sufficient for the portion of our proof of Theorem 1(iii) that depends on the greedy algorithm), after installing primesieve and primecount and compiling `egs.c` using `build.sh`, you can type
+To verify the Erdos-Guy-Selfridge conjecture for $$N$$ in $$[67425,10^{11}]$$ (which is sufficient for the portion of our proof of Theorem 1(iii) that depends on the greedy algorithm), after installing [primesieve](https://github.com/kimwalisch/primesieve) (version 12.6 or later, note that many libprimesieve-dev apt packages are older than this) and [primecount](https://github.com/kimwalisch/primecount) (version 7.14 or later), and compiling `egs.c` using `build.sh`, you can type
 ```
 ./egs -h hint_67425_1e6_exhaustive_greedy.txt 67425-1e6
 ./egs -f -h hint_1e6_1e11_heuristic_fast.txt 1e6-1e11

--- a/src/fastegs/build.sh
+++ b/src/fastegs/build.sh
@@ -1,1 +1,2 @@
+# you need to install primesieve version 12.6 or later and primecount version 7.14 or later
 gcc -O3 -fopenmp -o egs egs.c -lprimesieve -lprimecount -lstdc++ -lm

--- a/src/fastegs/egs.c
+++ b/src/fastegs/egs.c
@@ -390,6 +390,7 @@ int64_t tfac (int64_t N, int64_t t, int fast, int feasible, int verbosity, int v
     }
     if ( verbosity > 2 ) fprintf(stderr,"cnt=%ld for %ld p in [s,t) (%.6fs)\n", cnt, lastpi-maxpi, get_time()-start);
     assert (lastpi == pi(t-1));
+
     // Finally, handle primes p  in [t,N]
     if ( 3*t <= N ) {
         nextpi = pi(N/3);
@@ -580,7 +581,7 @@ int64_t tfac (int64_t N, int64_t t, int fast, int feasible, int verbosity, int v
     }
     if ( v ) fac_free(v);
 
-    free (E); E = 0;
+    free (E);
     return cnt;
 }
 


### PR DESCRIPTION
This PR updates the README.md and build.sh files in src/fastegs to note the minimum versions of primesieve and primecount that need to be installed before compiling egs.c (and notes that libprimesieve-dev apt packages are older than is required, and noted in #78).  There are also a few tiny (purely cosmetic) cleanups in egs.c.