### PR TITLE
Fix stale README links and small typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ Secondary goals are
 - [Upper and lower bounds for t(N) for randomly sampled N between 10^3 and 10^5](https://github.com/teorth/erdos-guy-selfridge/blob/main/Data/t_large_n_bounds.txt) - obtained by linear programming
 - [Upper and lower bounds for t(N) for N between 10^3 and 10^5 that are multiples of 100](https://github.com/teorth/erdos-guy-selfridge/blob/main/Data/t_large_n_bounds_2.txt) - obtained by linear programming
 - [Upper and lower bounds for t(N) for round number N between 10^5 and 10^9](https://github.com/teorth/erdos-guy-selfridge/blob/main/Data/lp_large_n.txt) - obtained by linear programming
-- [Lower bounds for t(N) for round N between 10^4 and 10^12](https://github.com/teorth/erdos-guy-selfridge/blob/main/src/fastegs/tbounds_heuristic_fast_greedy_1e4_1e12.txt) - obtained by a heuristic fast greedy method
-- [Lower bounds for t(N) for round N between 10^4 and 10^9](https://github.com/teorth/erdos-guy-selfridge/blob/main/src/fastegs/tbounds_exhaustive_fast_greedy_1e4_1e9.txt) - obtained by an exhaustive fast greedy method
+- [Lower bounds for t(N) for round N between 10^4 and 10^14](https://github.com/teorth/erdos-guy-selfridge/blob/main/src/fastegs/tbounds_heuristic_fast_1e4_1e14.txt) - obtained by a heuristic fast greedy method
+- [Lower bounds for t(N) for round N between 10^4 and 10^9](https://github.com/teorth/erdos-guy-selfridge/blob/main/src/fastegs/tbounds_exhaustive_fast_1e4_1e9.txt) - obtained by an exhaustive fast greedy method
 - [Lower bounds for t(N) for round N between 10^4 and 10^9](https://github.com/teorth/erdos-guy-selfridge/blob/main/src/fastegs/tbounds_heuristic_greedy_1e4_1e9.txt) - obtained by a heuristic greedy method
-- [Lower bounds for t(N) for round N between 10^4 and 10^8](https://github.com/teorth/erdos-guy-selfridge/blob/main/src/fastegs/tbounds_exhaustive_greedy_1e4_1e8.txt) - obtained by an exhaustive greedy method
+- [Lower bounds for t(N) for round N between 10^4 and 10^9](https://github.com/teorth/erdos-guy-selfridge/blob/main/src/fastegs/tbounds_exhaustive_greedy_1e4_1e9.txt) - obtained by an exhaustive greedy method
 - [Lower bounds for t(N) for N between 40000 and 45000](https://github.com/teorth/erdos-guy-selfridge/blob/main/Data/lp_bounds_40000-45000.txt) - uses "floor + residuals" linear programming method
 - Values of t(N) when one restricts to only being able to rearrange small primes: [2 only](https://github.com/teorth/erdos-guy-selfridge/blob/main/Data/rearrange/up_to_2.txt), [up to 3](https://github.com/teorth/erdos-guy-selfridge/blob/main/Data/rearrange/up_to_3.txt), [up to 5](https://github.com/teorth/erdos-guy-selfridge/blob/main/Data/rearrange/up_to_5.txt), [up to 7](https://github.com/teorth/erdos-guy-selfridge/blob/main/Data/rearrange/up_to_7.txt).
 

--- a/src/fastegs/README.md
+++ b/src/fastegs/README.md
@@ -1,10 +1,10 @@
-This directory contains a fast, memory efficient implemention of a variant of the greedy algorithm that yields sligtly worse lower bounds on $$t(N)$$ in general, but is able to verify the Erdős-Guy-Selfridge conjecture for $$N \in [10^6,10^{14}]$$ in less then ten minutes using just a few GB of memory (the space complexity of our implemention is $$O(N^{\frac{5}{8}+\epsilon})$$).
+This directory contains a fast, memory efficient implementation of a variant of the greedy algorithm that yields slightly worse lower bounds on $$t(N)$$ in general, but is able to verify the Erdős-Guy-Selfridge conjecture for $$N \in [10^6,10^{14}]$$ in less than ten minutes using just a few GB of memory (the space complexity of our implementation is $$O(N^{\frac{5}{8}+\epsilon})$$).
 
-An implementation of the standard greedy algorithm is included in the same program, but it's range is restricted to $$N\le 10^9$$ to keep the memory requirement low.
+An implementation of the standard greedy algorithm is included in the same program, but its range is restricted to $$N\le 10^9$$ to keep the memory requirement low.
 
-This implemention depends on Kim Walisch's [primesieve](https://github.com/kimwalisch/primesieve) and [primecount](https://github.com/kimwalisch/primecount) libraries for enumerating and counting primes, which must be installed before you compile the code in this directory.
+This implementation depends on Kim Walisch's [primesieve](https://github.com/kimwalisch/primesieve) and [primecount](https://github.com/kimwalisch/primecount) libraries for enumerating and counting primes, which must be installed before you compile the code in this directory.
 
-These two libraries are used to efficiently handle factors divisible by primes in the range $$[\sqrt{t},N]$$. In this range the greedy algorithm can always use the optimal cofactor $$m = \lceil\frac{t}{p}\rceil$$ to construct $$n = v_p(N!)$$ factors $$mp \ge t$$ that are as small as possible (given that they are divisible by $p$).  To improve efficiency, the algorithm subdivides the interval $$[\sqrt{t},N]$$ into regions within which the values of $m$ and $n$ are constant and simply counts the primes in each region (for small regions it uses `primesieve` to enuemrate primes, for large regions $$[a,b]$$ it uses `primecount` to compute $$\pi(b)-\pi(a-1))$$.  See the paper for more details.
+These two libraries are used to efficiently handle factors divisible by primes in the range $$[\sqrt{t},N]$$. In this range the greedy algorithm can always use the optimal cofactor $$m = \lceil\frac{t}{p}\rceil$$ to construct $$n = v_p(N!)$$ factors $$mp \ge t$$ that are as small as possible (given that they are divisible by $p$).  To improve efficiency, the algorithm subdivides the interval $$[\sqrt{t},N]$$ into regions within which the values of $m$ and $n$ are constant and simply counts the primes in each region (for small regions it uses `primesieve` to enumerate primes, for large regions $$[a,b]$$ it uses `primecount` to compute $$\pi(b)-\pi(a-1))$$.  See the paper for more details.
 
 To verify the Erdos-Guy-Selfridge conjecture for $$N$$ in $$[67425,10^{11}]$$ (which is sufficient for the portion of our proof of Theorem 1(iii) that depends on the greedy algorithm), after installing [primesieve](https://github.com/kimwalisch/primesieve) (version 12.6 or later, note that many libprimesieve-dev apt packages are older than this) and [primecount](https://github.com/kimwalisch/primecount) (version 7.14 or later), and compiling `egs.c` using `build.sh`, you can type
 ```
@@ -58,7 +58,7 @@ Usage: egs [-v level] [-h filename] [-d filename] [-r] [-c] [-e] [-f] N-range [t
        -c            create hint-file rather than reading it (must be specified in combination with -h)
        -e            use the best t for which the algorithm can prove t(N) >= t (optional)
        -f            use fast version of greedy algorithm
-       -m            exponent for primecount/primesieve cutuff, must lie in [1/6,1/3]
+       -m            exponent for primecount/primesieve cutoff, must lie in [1/6,1/3]
        N-range       integer N or range of integers minN-maxN (required, scientific notation supported)
        t             integer t to use for single N (optional, a good t will be determined if unspecified)
        t/N ratio     a/b with integers a,b>0 specifying t = ceil(aN/b) (optional, set to 1/3 if unspecified)

--- a/src/fastegs/egs.c
+++ b/src/fastegs/egs.c
@@ -654,7 +654,7 @@ static void usage (void)
         "       -c            create hint-file rather than reading it (must be specified in combination with -h)\n"
         "       -e            use the best t for which the algorithm can prove t(N) >= t (optional)\n"
         "       -f            use fast version of greedy algorithm\n"
-        "       -m            exponent for primecount/primesieve cutuff, must lie in [1/6,1/3]\n"
+        "       -m            exponent for primecount/primesieve cutoff, must lie in [1/6,1/3]\n"
         "       N-range       integer N or range of integers minN-maxN (required, scientific notation supported)\n"
         "       t             integer t to use for single N (optional, a good t will be determined if unspecified)\n"
         "       t/N ratio     a/b with integers a,b>0 specifying t = ceil(aN/b), set to 1/3 if unspecified\n");

--- a/src/mojo/README.md
+++ b/src/mojo/README.md
@@ -10,7 +10,7 @@ The program is written in [Mojo](https://docs.modular.com/mojo/manual/). To
 install Mojo, follow the install instructions in the [getting started
 guide](https://docs.modular.com/mojo/manual/get-started).
 
-The run the program, change into this directory and start a Magic shell
+To run the program, change into this directory and start a Magic shell
 ```sh
 cd src/mojo/
 magic shell
@@ -25,7 +25,7 @@ You should see the output
 `OEIS result: N = 300000  t(N) = 101903  T_ub = 101906`  
 as the final output line.
 
-When the program is invoked with to arguments, the second argument is a filename
+When the program is invoked with two arguments, the second argument is a filename
 and the program writes the lower bound factorization to disk.
 
 To run the program for a single fixed threshold $`t`$, invoke it with the


### PR DESCRIPTION
Fixed a few stale README links and small typos I noticed while looking through the repo.