### PR TITLE
Fix typos in the c_1 constants

### DIFF
--- a/LaTeX/notes.tex
+++ b/LaTeX/notes.tex
@@ -1082,7 +1082,7 @@ We can now prove the upper bound portion of \Cref{main}(iv):
     $$ \frac{t(N)}{N} \leq \frac{1}{e} - \frac{c_0}{\log N} - \frac{c_1 + o(1)}{\log^2 N}$$
     where $c_0$ is given by \eqref{c0-def} and $c_1$ is given by
     \begin{align}
-      c'_1 &\coloneqq \frac{1}{e} \int_0^1 f_e(x) \log \frac{1}{x}\ dx = 0.3702015\dots \label{c1p-def}\\
+      c'_1 &\coloneqq \frac{1}{e} \int_0^1 f_e(x) \log \frac{1}{x}\ dx = 0.3702051\dots \label{c1p-def}\\
       c''_1 &\coloneqq \sum_{k=1}^\infty \frac{1}{k}  \log\left( \frac{e}{k} \left\lceil \frac{k}{e} \right\rceil \right) = 1.679578996\dots\label{c1pp-def}\\
       c_1 &\coloneqq c'_1 + c_0 c''_1 - ec_0^2/2 =0.75554808\dots.\label{c1-def}
     \end{align}
@@ -1131,13 +1131,13 @@ From \eqref{c0-def}, \eqref{falpha-bound} we have
 $$ \int_{1/\log^2 N}^1 \left\lfloor \frac{1}{x} \right\rfloor \log\left(ex \left\lceil \frac{1}{ex} \right\rceil \right) = ec_0 - \frac{o(1)}{\log N},$$
 so it suffices to show that
 $$
-\int_{1/log^2 N}^{N/et}
-\left(\left\lfloor \frac{N/et}{x} \right\rfloor - \left\lfloor \frac{1}{x} \right\rfloor\right) \log\left(ex \left\lceil \frac{1}{ex} \right\rceil \right)\ dx \geq \frac{ec_0 c'' - e\eps + o(1)}{\log N}.$$
+\int_{1/\log^2 N}^{N/et}
+\left(\left\lfloor \frac{N/et}{x} \right\rfloor - \left\lfloor \frac{1}{x} \right\rfloor\right) \log\left(ex \left\lceil \frac{1}{ex} \right\rceil \right)\ dx \geq \frac{ec_0 c''_1 - e\eps + o(1)}{\log N}.$$
 Let $K$ be sufficiently large depending on $\eps$, then for $N$ sufficiently large depending on $K$ we can lower bound the left-hand side by
 $$ \sum_{k=1}^K \int_{1/k}^{N/etk} \log\left(ex \left\lceil \frac{1}{ex} \right\rceil \right)\ dx;$$
 since $\frac{N}{etk} = \frac{1}{k} + \frac{ec_0}{k \log N}$, we can lower bound this (using the irrationality of $e$) by
 $$ \frac{ec_0+o(1)}{\log N} \sum_{k=1}^K \frac{1}{k} \log\left(\frac{e}{k} \left\lceil \frac{k}{e} \right\rceil\right)$$
-for sufficiently large $N$.  Since the sum here can be made arbitrarily close to $c''_0$ by increasing $K$, we obtain the claim.
+for sufficiently large $N$.  Since the sum here can be made arbitrarily close to $c''_1$ by increasing $K$, we obtain the claim.
 \end{proof}
 
 We can now establish \Cref{main}(i):
@@ -2472,7 +2472,7 @@ $$ |S_{n,K}| \leq \frac{2}{|e^{-2\pi i n/e}-1| (K+1)^2} = \frac{1}{(K+1)^2 \sin(
 Because the irrationality measure of $e$ is $2$, this will give error terms of the shape $O(\log K/K^2)$ if one sets $N \approx K / \log K$.  Setting for instance $K = 10^6$, $N = 10^5$, an interval arithmetic computation then gives
 $$c''_1 = 1.679578996\dots$$
 and thus by \eqref{c1-def} we have
-$$ c_1 = 0.7554808\dots.$$
+$$ c_1 = 0.75554808\dots.$$
 This concludes our discussion of the numerical estimation of $c_0, c'_1, c''_1, c_1$.
 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 For a natural number $N$, let $t(N)$ be the largest number such that $N!$ can be factored into $N$ integer factors, each of which is at least $t(N)$.  It is known that $\frac{1}{e} - \frac{c_0+O(\log^{-c} N)}{\log N} \leq \frac{t(N)}{N} \leq \frac{1}{e} - \frac{c_0}{\log N} -\frac{c_1+o(1)}{\log^2 N}$,
 where $c_0 := \frac{1}{e} \int_0^1 \left \lfloor \frac{1}{x} \right\rfloor \log \left( ex \left \lceil \frac{1}{ex} \right\rceil \right)\ dx = 0.304419010\dots,$
-answering a question of [Erdős and Graham](https://www.erdosproblems.com/391).  Here $c_1$ is the explicit constant $c_1 := c^\prime_1 + c_0 {c_1}^{\prime\prime} - ec_0^2/2 = 0.75554808\dots$, where ${c_1}^\prime := \frac{1}{e} \int_0^1 \left \lfloor \frac{1}{x} \right\rfloor \log \left( ex \left \lceil \frac{1}{ex} \right\rceil \right) \log \frac{1}{x}\ dx = 0.3702051\dots$ and ${c_1}^{\prime\prime} :=  \sum_{k=1}^\infty \frac{1}{k}  \log\left( \frac{e}{k} \left\lceil \frac{k}{e} \right\rceil \right) = 1.679587996\dots$. 
+answering a question of [Erdős and Graham](https://www.erdosproblems.com/391).  Here $c_1$ is the explicit constant $c_1 := c^\prime_1 + c_0 {c_1}^{\prime\prime} - ec_0^2/2 = 0.75554808\dots$, where ${c_1}^\prime := \frac{1}{e} \int_0^1 \left \lfloor \frac{1}{x} \right\rfloor \log \left( ex \left \lceil \frac{1}{ex} \right\rceil \right) \log \frac{1}{x}\ dx = 0.3702051\dots$ and ${c_1}^{\prime\prime} :=  \sum_{k=1}^\infty \frac{1}{k}  \log\left( \frac{e}{k} \left\lceil \frac{k}{e} \right\rceil \right) = 1.679578996\dots`.
 
 Here is a graph of the integral defining $c_0$:
 
@@ -116,5 +116,4 @@ Secondary goals are
 - "[Decomposing a factorial into large factors](https://terrytao.wordpress.com/2025/03/26/decomposing-a-factorial-into-large-factors/)", blog post, Terence Tao, 26 March 2025.
 - [Decomposing a factorial into large factors](https://arxiv.org/abs/2503.20170), arXiv preprint v2, Terence Tao, 28 March 2025.
 - [Notes on criteria for bounding t(N)](https://github.com/teorth/erdos-guy-selfridge/blob/main/LaTeX/notes.pdf)
-
 

--- a/src/python/interval/README.md
+++ b/src/python/interval/README.md
@@ -1,0 +1,28 @@
+# Interval computations
+
+This directory contains scripts for the interval arithmetic computations used in the paper.
+
+* `interval_constants.py` computes rigorous intervals for the constants
+  $c_0$ and $c_1$.
+
+* `interval_computations.py` checks the interval estimates used in the
+  proof of the modified approximate factorization bounds.
+
+To reproduce the constants, run the following from the repository root:
+
+```
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install -r src/python/interval/requirements.txt
+MPLCONFIGDIR=/tmp/erdos-guy-selfridge-mpl python src/python/interval/interval_constants.py
+```
+
+The final output should include intervals of the following form:
+
+```
+c0 = [0.30441901064575277447, 0.30441901109754626598]
+c1 = [0.75554808426110209307, 0.75554808757613112213]
+```
+
+The `MPLCONFIGDIR` setting is only used to avoid Matplotlib cache warnings
+on systems where the default home-directory cache is not writable.

--- a/src/python/interval/requirements.txt
+++ b/src/python/interval/requirements.txt
@@ -1,0 +1,3 @@
+matplotlib
+mpmath
+numpy


### PR DESCRIPTION
Fixed a few inconsistent c_1 values and notation slips I noticed while checking the interval computations. I also added a short note on rerunning the interval scripts.
