### PR TITLE
[LOGIC]: Correct assertion of f[j]

### DIFF
--- a/src/linprog/smoothfac.py
+++ b/src/linprog/smoothfac.py
@@ -134,7 +134,7 @@ def main(N: int, T: int, filename: Optional[str], lp_filename: Optional[str]):
     for j in range(T, N+1):
         if f[j] <= 0:
             continue
-        assert f[i] > 1
+        assert f[j] > 1
         cj = gp.Column()
         for (i, fij) in coliter(f, j):
             cj.addTerms(fij, row[i])


### PR DESCRIPTION
I'm not 100% sure if this fix is correct because I haven't tested it, but in my opinion it seems pretty likely that the intended behaviour was not to assert f[i] (which is used in a for loop before this statement (and maybe technically still accessable, but probably not intended to be accessed)), but instead f[j] (most likely), but please correct me if I'm mistaken.

Contributed by Benedikt Johannes