### PR TITLE
fix: correct direction of bv-lower bound

### DIFF
--- a/LaTeX/notes.tex
+++ b/LaTeX/notes.tex
@@ -607,7 +607,7 @@ and the lower bound
 \end{equation}
 and the lower bound
 \begin{equation}\label{bv-lower}
-  \sum_{y < p \leq x} b(p) \leq \frac{1-\frac{2}{\sqrt{y}}}{\log x} \int_y^x b(t)\ dt - \|b\|_{\mathrm{TV}^*(y,x]} \frac{E(x)}{\log x}.
+  \sum_{y < p \leq x} b(p) \geq \frac{1-\frac{2}{\sqrt{y}}}{\log x} \int_y^x b(t)\ dt - \|b\|_{\mathrm{TV}^*(y,x]} \frac{E(x)}{\log x}.
 \end{equation}
 \end{itemize}
 One can replace all occurrences of $E(x)$ here by the classical error term $O(x \exp(-c \sqrt{\log x}))$ for some absolute constant $c>0$ (in which case the $\frac{2}{\sqrt{t}}$ type terms can be absorbed into the error term).


### PR DESCRIPTION
## Summary
Fixes the inequality direction in \eqref{bv-lower} (Lemma, sums over primes).

## Bug
The displayed bound is labeled a **lower** bound on `\sum_{y<p\le x} b(p)`, but the relation used `\le` on the RHS. For a lower bound the sum should be `\ge` the RHS.

## Root cause
Typo when stating \eqref{bv-lower}; the companion upper bound \eqref{bv-upper} correctly uses `\le`.

## Why this fix is correct
The line is explicitly introduced as a lower bound, and the proof at the end of Appendix A derives these bounds from `b(p)\log p/\log x \le b(p) \le b(p)\log p/\log y`.

Re-applies the mathematical part of #105 without the unrelated author-list changes that caused #108 to revert it.


Made with [Cursor](https://cursor.com)