### PR TITLE
fix: correct exponent a in fancy-kappa definition

### DIFF
--- a/LaTeX/notes.tex
+++ b/LaTeX/notes.tex
@@ -498,7 +498,7 @@ If $1 \leq L \leq x$ is an additional real parameter, we define
 \begin{equation}\label{fancy-kappa-def}
   \lceil x \rceil^{\langle 2,3\rangle}_L \coloneqq 12^a \lceil x/12^a \rceil^{\langle 2,3 \rangle}
 \end{equation}
-for any real $x \geq L \geq 1$, where $a \coloneqq \left\lfloor \frac{x/L}{\log 12} \right\rfloor$ is the largest integer such that $12^a \leq x/L$.
+for any real $x \geq L \geq 1$, where $a \coloneqq \left\lfloor \frac{\log(x/L)}{\log 12} \right\rfloor$ is the largest integer such that $12^a \leq x/L$.
 
 For any $L \geq 1$, let $\kappa_L$ be the least quantity such that
 \begin{equation}\label{kappa-def}


### PR DESCRIPTION
## Summary

In `\eqref{fancy-kappa-def}`, the exponent `a` is defined as the largest integer with `12^a ≤ x/L`. That requires `a = ⌊log(x/L)/log(12)⌋`, not `⌊(x/L)/log(12)⌋`.

## Root cause

PR #106 fixed this, but #107 reverted it; main still has the wrong formula.

## Fix

One-line change in `LaTeX/notes.tex` (no PDF rebuild).

Closes #106

Made with [Cursor](https://cursor.com)