### PR TITLE
fix: pass K to delta2_upper in evaluate()

### DIFF
--- a/src/python/interval/calculations.py
+++ b/src/python/interval/calculations.py
@@ -344,7 +344,7 @@ def evaluate(t, N, A, K, L):
 
     delta = delta_lower(t, N)
     delta1 = delta1_upper(t, N, A, delta)
-    delta2 = delta2_upper(t, N, delta)
+    delta2 = delta2_upper(t, N, K, delta)
     delta3 = delta3_upper(t, N, A, K, delta)
     delta4 = delta4_upper(t, N, A, K, sigma, delta)
     delta5 = delta5_upper(t, N, A, K, sigma, delta)


### PR DESCRIPTION
## Summary

`delta2_upper` takes `(t, N, K, delta)` since #104, but `evaluate()` still called it as `(t, N, delta)`, so running the script raises `TypeError`.

## Root cause

#104 updated the function signature for Lemma 2.2 but missed the call site in `evaluate()`.

## Fix

Pass `K` through in the one call in `evaluate()`.

Made with [Cursor](https://cursor.com)